### PR TITLE
Codespell finds typos

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,7 +13,7 @@ jobs:
                          flake8-comprehensions isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B301,B403,B605 .
       - run: black --check . || true
-      - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
                       --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,7 +13,7 @@ jobs:
                          flake8-comprehensions isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B301,B403,B605 .
       - run: black --check . || true
-      - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: codespell --ignore-words-list=nwe  # --skip="*.css,*.js,*.lock"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
                       --show-source --statistics

--- a/PyPrograms/tkinter/helloworld/helloworld.py
+++ b/PyPrograms/tkinter/helloworld/helloworld.py
@@ -1,9 +1,9 @@
 # This program uses the GPL V3 Licence. Read the file LICENCE to see it.
 # By @bupboi1337
-# Editors can put thier names down here:
+# Editors can put their names down here:
 #
 from tkinter import * # Import Tkinter
 root = Tk()
 a = Label(root, text ="Hello World!") # Store the code to make Hello World to appear in a GUI as the variable a.
-a.pack() # Initilize the variable a so when the GUI is initilized the text will appear.
-root.mainloop() # Initilize the GUI window.
+a.pack() # Initialize the variable a so when the GUI is initialized the text will appear.
+root.mainloop() # Initialize the GUI window.


### PR DESCRIPTION
$ `codespell`
```
./PyPrograms/tkinter/helloworld/helloworld.py:3: thier ==> their
./PyPrograms/tkinter/helloworld/helloworld.py:8: Initilize ==> Initialize
./PyPrograms/tkinter/helloworld/helloworld.py:8: initilized ==> initialized
./PyPrograms/tkinter/helloworld/helloworld.py:9: Initilize ==> Initialize
./PyPrograms/tkinter/box/box.py:3: thier ==> their
./PyPrograms/tkinter/box/box.py:7: Initalize ==> Initialize
./PyPrograms/decimal-to-binary/readme.md:8: interpretor ==> interpreter
./PyPrograms/decimal-to-binary/readme.md:13: Contributers ==> Contributors
./PyPrograms/contacts/readme.md:8: Requirments ==> Requirements
./PyPrograms/contacts/readme.md:9: interpretor ==> interpreter
./PyPrograms/contacts/readme.md:15: Contributers ==> Contributors
./PyPrograms/contacts/readme.md:19: grammer ==> grammar
./PyPrograms/contacts/main.py:31: OCCURED ==> OCCURRED
./PyPrograms/contacts/main.py:130: SUCESSFULLY ==> SUCCESSFULLY
./PyPrograms/contacts/encrypt10n.py:86: WONT ==> WON'T
./PyPrograms/contacts/encrypt10n.py:100: CONVET ==> CONVERT
./PyPrograms/contacts/docs/reset-data.py:10: sucess ==> success
./PyPrograms/contacts/docs/reset-data.py:11: SUCESSFUL ==> SUCCESSFUL
./PyPrograms/contacts/docs/requirements.txt:4: interpretor ==> interpreter
./PyPrograms/contacts/docs/requirements.txt:6: recommand ==> recommend
./PyPrograms/raspberry-pi-detector/readme.md:6: thier ==> their
./PyPrograms/raspberry-pi-detector/rpi-detector.py:16: sucessfully ==> successfully
./PyPrograms/sysinfo/readme.md:3: Informaiton ==> Information
./PyPrograms/sysinfo/readme.md:7: informaiton ==> information
./PyPrograms/sysinfo/sysinfo.py:1: Informaiton ==> Information
./PyPrograms/areas/readme.md:7: interpretor ==> interpreter
./PyPrograms/areas/readme.md:12: Contributers ==> Contributors
./PyPrograms/areas/areas.py:17: nwe ==> new
./PyPrograms/equations/readme.md:8: interpretor ==> interpreter
./PyPrograms/equations/readme.md:13: Contributers ==> Contributors
./PyPrograms/box/readme.md:12: thier ==> their
./PyPrograms/box/box.py:1: Becuase ==> Because
```